### PR TITLE
Fix SVG not rendering

### DIFF
--- a/units/git/vcs-git-and-github.md
+++ b/units/git/vcs-git-and-github.md
@@ -22,7 +22,7 @@ VCS, Git & GitHub
  * Every clone is really a full backup of the repository
  * Example: Git, Mercurial, etc.
 
-![](./distributed-git.svg)
+![](https://rawgit.com/kabirbaidhya/learn-python-django-web/master/units/git/distributed-git.svg)
 
 ## Git
 


### PR DESCRIPTION
GitHub no longer renders SVG directly from raw.github.com. It's treated as a text file now. I used rawgit.com to render the SVG in markdown.